### PR TITLE
Empty iss for each loop

### DIFF
--- a/LUMA/src/GridObj_ops_io.cpp
+++ b/LUMA/src/GridObj_ops_io.cpp
@@ -524,6 +524,7 @@ void GridObj::io_restart(eIOFlag IO_flag) {
 		{
 
 			// Get line and put in buffer
+			iss.clear();
 			std::getline(file,line_in,'\n');
 			iss.str(line_in);
 			iss.seekg(0); // Reset buffer position to start of buffer


### PR DESCRIPTION
After the first iteration, `iss` will always have data from all the previously read lines, causing incorrect or unexpected results in the subsequent iterations.